### PR TITLE
Added support to register templates and obtain status

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 var cacheFile string

--- a/params.go
+++ b/params.go
@@ -67,11 +67,11 @@ func parseParams(rawParams string) (csparams, error) {
 	}
 	paramSlice := strings.Split(rawParams, ",")
 	for _, paramSet := range paramSlice {
-		keyValue := strings.Split(paramSet, ":")
+		keyValue := strings.SplitN(paramSet, ":", 2)
 		if len(keyValue) != 2 || len(keyValue[value]) == 0 {
 			return nil, fmt.Errorf("Error processing parameters around: ... %s ...", paramSet)
 		}
-		params[strings.ToLower(strings.Trim(strings.TrimSpace(keyValue[key]), `"`))] = strings.ToLower(strings.Trim(strings.TrimSpace(keyValue[value]), `"`))
+		params[strings.ToLower(strings.Trim(strings.TrimSpace(keyValue[key]), `"`))] = strings.Trim(strings.TrimSpace(keyValue[value]), `"`)
 	}
 	return params, nil
 }


### PR DESCRIPTION
When using gocs to register a new template, I ran into three problems.  The first issue was registerTemplate takes a URL which messed up the parameter parsing.  The second issue was that while the API returns an ID, it doesn't follow the same convention as other API calls and only returned a "template".  The last issue was that no easy way existed to unmarshall random fields from the return JSON.  I made that a public export since I suspect I'll be using that elsewhere in my project.  I hope these changes work for you.